### PR TITLE
Bump to 0.5.1 (0.5.0 burned by stale TS release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [0.5.0] - 2026-04-16
+## [0.5.1] - 2026-04-16
 
 Applies to both the Python and TypeScript libraries. The tool contract is now identical across both SDKs.
+
+The 0.5.0 version number was burned by an earlier TypeScript-only release (npm `upjack@0.5.0`) that bumped the version without applying the flat-kwarg contract change described below. To keep the "same version = same contract" invariant across SDKs, the corrected release ships as 0.5.1. `upjack@0.5.0` on npm has been deprecated; please upgrade to 0.5.1.
 
 ### Changed
 - **Breaking:** Auto-generated `create_{name}` and `update_{name}` MCP tools now take flat kwargs at the top level. The `{data: {...}}` wrapper has been removed — pass entity fields directly, e.g. `create_deal({"title": "...", "amount": 1000, "stage": "qualified"})`. Mixing the old and new shapes in the same tool list was measurably confusing LLMs and driving ~30% tool-call failure rates on the auto-generated CRUD surface. The flat form matches the hand-written tool convention and the FastMCP / MCP SDK idiom.

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "upjack"
-version = "0.5.0"
+version = "0.5.1"
 description = "Schema-driven entity management for AI-native applications"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/lib/python/src/upjack/__init__.py
+++ b/lib/python/src/upjack/__init__.py
@@ -1,6 +1,6 @@
 """NimbleBrain Upjack — schema-driven entity management for AI-native applications."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 from upjack.activity import ACTIVITY_ENTITY_DEF, get_activity_schema
 from upjack.app import UpjackApp

--- a/lib/python/uv.lock
+++ b/lib/python/uv.lock
@@ -1179,7 +1179,7 @@ wheels = [
 
 [[package]]
 name = "upjack"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },

--- a/lib/typescript/package.json
+++ b/lib/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upjack",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Schema-driven entity management for AI-native applications",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Bumps both SDKs to 0.5.1. The 0.5.0 version number is unusable: `upjack@0.5.0` was published to npm from a stale TypeScript commit that bumped the version without applying the flat-kwarg contract change described in PR #22. To keep the "same version = same contract across SDKs" invariant promised in the CHANGELOG, we skip 0.5.0 and release the corrected code as 0.5.1.

## Files changed

- `lib/python/pyproject.toml` → 0.5.1
- `lib/python/src/upjack/__init__.py` → 0.5.1
- `lib/python/uv.lock` (regenerated)
- `lib/typescript/package.json` → 0.5.1
- `CHANGELOG.md` — header renamed to 0.5.1 with a note on the version skip

## Test plan

- [x] `make -C lib/python check` — 411 tests pass
- [x] `cd lib/typescript && npm test` — 282 tests pass
- [ ] After merge: tag `python-v0.5.1` + `typescript-v0.5.1` to trigger PyPI + npm publish
- [ ] `npm deprecate upjack@0.5.0 "published without the flat-kwarg contract change; please upgrade to 0.5.1"`

## Related

- Fixes ecosystem state after #22